### PR TITLE
Fix shitcode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "space-station-14"]
 	path = space-station-14
-	url = https://github.com/space-syndicate/space-station-14
+	url = https://github.com/space-wizards/space-station-14

--- a/ArabicaCliento/Systems/ArabicaSecurityIcons.cs
+++ b/ArabicaCliento/Systems/ArabicaSecurityIcons.cs
@@ -3,4 +3,4 @@ using Content.Shared.Overlays;
 
 namespace ArabicaCliento.Systems;
 
-public class ArabicaJobIconsSystem : LocalPlayerAddCompSystem<ShowSecurityIconsComponent>;
+public class ArabicaJobIconsSystem : LocalPlayerAddCompSystem<ShowJobIconsComponent>;


### PR DESCRIPTION
1. Change submodul to wizends repo
2. Remove **ShowJobIconsComponent** because **ShowSecurityIconsComponent** do error

## Summary by Sourcery

Fix an error by removing the ShowJobIconsComponent and update the submodule to the wizends repository.

Bug Fixes:
- Remove ShowJobIconsComponent to resolve an error caused by ShowSecurityIconsComponent.

Chores:
- Update submodule to point to the wizends repository.