### PR TITLE
Arabica Overlay

### DIFF
--- a/.idea/.idea.ArabicaCliento/.idea/.name
+++ b/.idea/.idea.ArabicaCliento/.idea/.name
@@ -1,0 +1,1 @@
+ArabicaCliento

--- a/ArabicaCliento/ArabicaConfig.cs
+++ b/ArabicaCliento/ArabicaConfig.cs
@@ -15,4 +15,6 @@ public static class ArabicaConfig
     public static float RangedAimbotRadius = 2f;
 
     public static bool SyndicateDetector = true;
+    
+    public static bool OverlayEnabled = false;
 }

--- a/ArabicaCliento/Commands/Arabica.EntityList.cs
+++ b/ArabicaCliento/Commands/Arabica.EntityList.cs
@@ -1,0 +1,49 @@
+using Content.Client.Administration.Systems;
+using Content.Shared.Administration;
+using Content.Shared.Body.Components;
+using Content.Shared.Damage;
+using Content.Shared.Movement.Components;
+using Content.Shared.NameIdentifier;
+using Robust.Client.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+
+namespace ArabicaCliento.Commands;
+
+[AnyCommand]
+public class ArabicaPlayers : IConsoleCommand
+{
+    public string Command => "arabica.entities";
+    public string Description => "Outputs a entity(human-controlable) list with their id, name and coordinates";
+    public string Help => "arabica.entities";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+
+        foreach (var entity in entityManager.GetEntities())
+        {
+            var ismob = entityManager.GetComponentOrNull<ActorComponent>(entity);
+            if (ismob != null)
+            {
+                var metadata = entityManager.GetComponentOrNull<MetaDataComponent>(entity);
+                var transformcomp = entityManager.GetComponentOrNull<TransformComponent>(entity);
+                var namestring = metadata.EntityName;
+                var desc = metadata.EntityDescription;
+                var username = entityManager.TryGetComponent<ActorComponent>(entity, out var Ckey);
+                var damage = entityManager.TryGetComponent<DamageableComponent>(entity, out var Alldamage);
+                var WorldCoord = transformcomp.WorldPosition;
+                shell.WriteLine($"Entity ID: {entity}");
+                shell.WriteLine($"Name: {namestring}");
+                shell.WriteLine($"Desc: {desc}");
+                shell.WriteLine($"Ckey: {Ckey.PlayerSession}");
+                shell.WriteLine($"OverAllDamage: {Alldamage.TotalDamage}");
+                shell.WriteLine($"World Cords x,y: {WorldCoord}");
+            
+                shell.WriteLine(""); 
+            }
+        }    
+        
+    }
+}

--- a/ArabicaCliento/Commands/Arabica.OverlayCommand.cs
+++ b/ArabicaCliento/Commands/Arabica.OverlayCommand.cs
@@ -1,0 +1,28 @@
+using Content.Shared.Administration;
+using Content.Shared.Damage;
+using Robust.Shared.Console;
+using Robust.Shared.Player;
+
+namespace ArabicaCliento.Commands;
+
+[AnyCommand]
+public class ArabicaOverlay : IConsoleCommand
+{
+    public string Command => "arabica.overlay";
+    public string Description => "nigg a";
+    public string Help => "arabica.overlay";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (ArabicaConfig.OverlayEnabled == false)
+        {
+            ArabicaConfig.OverlayEnabled = true;
+            shell.WriteLine("Overlay enabled");
+        }
+        else
+        {
+            ArabicaConfig.OverlayEnabled = false;
+            shell.WriteLine("Overlay disabled");
+        }
+    }
+}

--- a/ArabicaCliento/Commands/Arabica.OverlayCommand.cs
+++ b/ArabicaCliento/Commands/Arabica.OverlayCommand.cs
@@ -9,7 +9,7 @@ namespace ArabicaCliento.Commands;
 public class ArabicaOverlay : IConsoleCommand
 {
     public string Command => "arabica.overlay";
-    public string Description => "nigg a";
+    public string Description => "Shows Ckeys and CharNames of players";
     public string Help => "arabica.overlay";
 
     public void Execute(IConsoleShell shell, string argStr, string[] args)

--- a/ArabicaCliento/Overlays/ArabicaOverlay.cs
+++ b/ArabicaCliento/Overlays/ArabicaOverlay.cs
@@ -1,0 +1,60 @@
+using System.Numerics;
+using Content.Client.Administration.Systems;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+using Robust.Client.Player;
+using Robust.Client.ResourceManagement;
+using Robust.Client.UserInterface;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace ArabicaCliento.Overlays;
+
+public class ArabicaOverlay(
+    IEntityManager entManager, IEyeManager eye, EntityLookupSystem entityLookup, IResourceCache resourceCache, IUserInterfaceManager userInterfaceManager)
+    : Overlay
+{
+    public override OverlaySpace Space => OverlaySpace.ScreenSpace;
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var font = new VectorFont(resourceCache.GetResource<FontResource>("/Fonts/NotoSans/NotoSans-Regular.ttf"), 10);
+        
+        var viewport = args.WorldAABB;
+
+        foreach (var entity in entManager.GetEntities())
+        {
+            if (!entManager.EntityExists(entity))
+            {
+                continue;
+            }
+            if (entManager.GetComponent<TransformComponent>(entity).MapID != args.MapId)
+            {
+                continue;
+            }
+            
+            if(!ArabicaConfig.OverlayEnabled) return;
+
+            if (entManager.GetComponentOrNull<ActorComponent>(entity) != null)
+            {
+                var aabb = entityLookup.GetWorldAABB(entity);
+                var charactername = (entManager.GetComponent<MetaDataComponent>(entity)).EntityName;
+                var ckey = (entManager.GetComponent<ActorComponent>(entity)).PlayerSession.Name;
+                if (!aabb.Intersects(in viewport))
+                {
+                    continue;
+                }
+
+                var uiScale = userInterfaceManager.RootControl.UIScale;
+                var lineoffset = new Vector2(0f, 11f) * uiScale;
+                var screenCoordinates = eye.WorldToScreen(aabb.Center +
+                                                          new Angle(-eye.CurrentEye.Rotation).RotateVec(
+                                                              aabb.TopRight - aabb.Center)) + new Vector2(1f, 7f);
+
+                args.ScreenHandle.DrawString(font, screenCoordinates + lineoffset, ckey, uiScale, Color.Yellow);
+                args.ScreenHandle.DrawString(font, screenCoordinates, charactername, uiScale, Color.Aquamarine);
+            }
+        }
+    }
+}

--- a/ArabicaCliento/Overlays/ArabicaOverlay.cs
+++ b/ArabicaCliento/Overlays/ArabicaOverlay.cs
@@ -22,7 +22,9 @@ public class ArabicaOverlay(
         var font = new VectorFont(resourceCache.GetResource<FontResource>("/Fonts/NotoSans/NotoSans-Regular.ttf"), 10);
         
         var viewport = args.WorldAABB;
-
+        
+        if(!ArabicaConfig.OverlayEnabled) return;
+        
         foreach (var entity in entManager.GetEntities())
         {
             if (!entManager.EntityExists(entity))
@@ -34,8 +36,6 @@ public class ArabicaOverlay(
                 continue;
             }
             
-            if(!ArabicaConfig.OverlayEnabled) return;
-
             if (entManager.GetComponentOrNull<ActorComponent>(entity) != null)
             {
                 var aabb = entityLookup.GetWorldAABB(entity);

--- a/ArabicaCliento/Systems/ArabicaAddOverlay.cs
+++ b/ArabicaCliento/Systems/ArabicaAddOverlay.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using ArabicaCliento.Overlays;
+using ArabicaCliento.Systems.Abstract;
+using Content.Shared.Administration;
+using Robust.Client.Graphics;
+using Robust.Client.ResourceManagement;
+using Robust.Client.UserInterface;
+using Robust.Shared.Console;
+using Robust.Shared.Player;
+
+namespace ArabicaCliento.Systems;
+
+public class ArabicaAddOverlay(IEntityManager entManager, IEyeManager eye, EntityLookupSystem entityLookup, 
+    IResourceCache resourceCache, IUserInterfaceManager userInterfaceManager, IOverlayManager overlaymanager) : LocalPlayerSystem
+{
+    private ArabicaOverlay? overlay;
+
+    protected override void OnAttached(LocalPlayerAttachedEvent ev)
+    {
+        overlay ??= new ArabicaOverlay(entManager, eye, entityLookup, resourceCache, userInterfaceManager);
+        overlaymanager.AddOverlay(overlay);
+    }
+    protected override void OnDetached(LocalPlayerDetachedEvent ev)
+    {
+        overlaymanager.RemoveOverlay(overlay);
+    }
+}


### PR DESCRIPTION
### `namespace ArabicaCliento.Commands;`



🕵️‍♂️ **arabica.overlay**


Shows CKEYs and CharNames of players in the range of the local player.

📜 **arabica.entities**

Writes in console coordinates, CharNames, Ckeys, Overall health and world map coordinates of entity, each of them controlled by player.

## Summary by Sourcery

Add a new overlay feature to display player information within range and implement console commands for entity listing and overlay toggling.

New Features:
- Introduce an overlay feature that displays CKEYs and character names of players within the local player's range.
- Add a console command 'arabica.entities' to output a list of entities controlled by players, including their coordinates, character names, CKEYs, and health status.

Enhancements:
- Implement a toggle command 'arabica.overlay' to enable or disable the overlay feature.