### PR TITLE
stability improvement

### DIFF
--- a/ArabicaCliento/Patches/ClientAdminManagerPatch.cs
+++ b/ArabicaCliento/Patches/ClientAdminManagerPatch.cs
@@ -23,4 +23,11 @@ internal static class ClientAdminManagerPatch
         __result = true;
         return false;
     }
+    
+        
+    [HarmonyFinalizer]
+    private static void Finalizer(Exception __exception)
+    {
+        MarseyLogger.Fatal($"Error while patching ClientAdminManagerPatch: {__exception}");
+    }
 }

--- a/ArabicaCliento/Patches/ClientConGroupControllerPatch.cs
+++ b/ArabicaCliento/Patches/ClientConGroupControllerPatch.cs
@@ -25,4 +25,10 @@ internal static class ClientConGroupControllerPatch
         __result = true;
         return false;
     }
+    
+    [HarmonyFinalizer]
+    private static void Finalizer(Exception __exception)
+    {
+        MarseyLogger.Fatal($"Error while patching ClientConGroupControllerPatch: {__exception}");
+    }
 }

--- a/ArabicaCliento/Patches/ClientHeavyAttackPatch.cs
+++ b/ArabicaCliento/Patches/ClientHeavyAttackPatch.cs
@@ -8,7 +8,7 @@ using Robust.Client.GameObjects;
 namespace ArabicaCliento.Patches;
 
 [HarmonyPatch(typeof(MeleeWeaponSystem), "ClientHeavyAttack")]
-public class ClientHeavyAttackPatch
+internal class ClientHeavyAttackPatch
 {
     private static IEntityManager? _entMan;
     private static TransformSystem? _transform;
@@ -29,5 +29,11 @@ public class ClientHeavyAttackPatch
         var output = _aim.GetClosestToEntInRange(user, component.Range, [user]);
         if (output == null) return;
         coordinates = _transform.ToCoordinates(coordinates.EntityId, output.Value.Position);
+    }
+    
+    [HarmonyFinalizer]
+    private static void Finalizer(Exception __exception)
+    {
+        MarseyLogger.Fatal($"Error while patching ClientHeavyAttackPatch: {__exception}");
     }
 }

--- a/ArabicaCliento/Patches/ConsoleHostPatch.cs
+++ b/ArabicaCliento/Patches/ConsoleHostPatch.cs
@@ -3,17 +3,16 @@ using HarmonyLib;
 
 namespace ArabicaCliento.Patches;
 
-[HarmonyPatch]
+[HarmonyPatch("Robust.Client.Console.ClientConsoleHost", "CanExecute")]
 internal class ConsoleHostPatch
 {
-    [HarmonyTargetMethod]
-    private static MethodBase TargetMethod()
-    {
-        return AccessTools.Method(AccessTools.TypeByName("Robust.Client.Console.ClientConsoleHost"),
-            "CanExecute");
-        
-    }
-    
     [HarmonyPostfix]
     private static void Postfix(ref bool __result) => __result = true;
+
+
+    [HarmonyFinalizer]
+    private static void Finalizer(Exception __exception)
+    {
+        MarseyLogger.Fatal($"Error while patching ConsoleHostPatch: {__exception}");
+    }
 }

--- a/ArabicaCliento/Patches/DrawOcclusionDepthPatch.cs
+++ b/ArabicaCliento/Patches/DrawOcclusionDepthPatch.cs
@@ -6,8 +6,14 @@ namespace ArabicaCliento.Patches;
 internal static class DrawOcclusionDepthPatch
 {
     [HarmonyPrefix]
-    static bool Prefix()
+    private static bool Prefix()
     {
         return !ArabicaConfig.FOVDisable;
+    }
+    
+    [HarmonyFinalizer]
+    private static void Finalizer(Exception __exception)
+    {
+        MarseyLogger.Fatal($"Error while patching DrawOcclusionDepthPatch: {__exception}");
     }
 }

--- a/ArabicaCliento/Patches/EntityMenuElementPatch.cs
+++ b/ArabicaCliento/Patches/EntityMenuElementPatch.cs
@@ -9,11 +9,18 @@ namespace ArabicaCliento.Patches;
 internal class EntityMenuElementPatch
 {
     private static MethodInfo? _methodCache;
+    
     [HarmonyPrefix]
     private static bool Prefix(EntityUid entity, EntityMenuElement __instance, ref string __result)
     {
         _methodCache ??= AccessTools.Method(typeof(EntityMenuElement), "GetEntityDescriptionAdmin");
         __result = _methodCache.Invoke(__instance, [entity]) as string ?? throw new InvalidOperationException();
         return false;
+    }
+    
+    [HarmonyFinalizer]
+    private static void Finalizer(Exception __exception)
+    {
+        MarseyLogger.Fatal($"Error while patching EntityMenuElementPatch: {__exception}");
     }
 }

--- a/ArabicaCliento/Patches/GunUpdatePatch.cs
+++ b/ArabicaCliento/Patches/GunUpdatePatch.cs
@@ -11,7 +11,7 @@ using Robust.Shared.Map;
 namespace ArabicaCliento.Patches;
 
 [HarmonyPatch(typeof(GunSystem), nameof(GunSystem.Update))]
-public class GunUpdatePatch
+internal class GunUpdatePatch
 {
     private static EntityManager? _entMan;
     private static IInputManager? _input;
@@ -56,5 +56,11 @@ public class GunUpdatePatch
         codes[index - 1] = new CodeInstruction(OpCodes.Call, methodInfo); // Before stfld goes call
 
         return codes.AsEnumerable();
+    }
+    
+    [HarmonyFinalizer]
+    private static void Finalizer(Exception __exception)
+    {
+        MarseyLogger.Fatal($"Error while patching GunUpdatePatch: {__exception}");
     }
 }

--- a/ArabicaCliento/Patches/MouseRotatorPatch.cs
+++ b/ArabicaCliento/Patches/MouseRotatorPatch.cs
@@ -8,4 +8,10 @@ internal class MouseRotatorPatch
 {
     [HarmonyPrefix]
     private static bool Prefix() => false;
+    
+    [HarmonyFinalizer]
+    private static void Finalizer(Exception __exception)
+    {
+        MarseyLogger.Fatal($"Error while patching MouseRotatorPatch: {__exception}");
+    }
 }

--- a/ArabicaCliento/Patches/OverlaysPatch.cs
+++ b/ArabicaCliento/Patches/OverlaysPatch.cs
@@ -25,4 +25,10 @@ internal static class OverlaysPatch
     {
         return !ArabicaConfig.OverlaysDisable;
     }
+    
+    [HarmonyFinalizer]
+    private static void Finalizer(Exception __exception)
+    {
+        MarseyLogger.Fatal($"Error while patching OverlaysPatch: {__exception}");
+    }
 }


### PR DESCRIPTION
title :1st_place_medal: 
- [X] Add finalizers to patches
- [ ] Add build test
- [ ] Remove `LocalPlayerAddCompSystem` with generic and replace with type-checking systems

## Summary by Sourcery

Add Harmony finalizers for robust error handling in patches, streamline patch definitions, and standardize class modifiers to improve client stability

Enhancements:
- Add HarmonyFinalizer methods with fatal logging to all patch classes
- Simplify HarmonyPatch usage by specifying target in attributes and remove redundant TargetMethod methods
- Standardize patch class access modifiers to internal and unify prefix method visibility